### PR TITLE
Make ScalacOptions trait accessible via a singleton object

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.0"
+ThisBuild / tlBaseVersion := "0.1"
 
 ThisBuild / organization     := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"

--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -19,7 +19,9 @@ package org.typelevel.scalacoptions
 import scala.Ordering.Implicits._
 import scala.collection.immutable.ListSet
 
-object ScalacOptions {
+object ScalacOptions extends ScalacOptions
+
+private[scalacoptions] trait ScalacOptions {
   import ScalaVersion._
 
   /** Provide another option that is not declared by the ScalacOptions DSL.

--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -19,7 +19,7 @@ package org.typelevel.scalacoptions
 import scala.Ordering.Implicits._
 import scala.collection.immutable.ListSet
 
-private[scalacoptions] trait ScalacOptions {
+object ScalacOptions {
   import ScalaVersion._
 
   /** Provide another option that is not declared by the ScalacOptions DSL.


### PR DESCRIPTION
This library is not particularly usable without this change 😆 