### PR TITLE
name root module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+name := "scalac-options-root"
+
 ThisBuild / tlBaseVersion := "0.1"
 
 ThisBuild / organization     := "org.typelevel"


### PR DESCRIPTION
A very simple change that gives an explicit and distinctive name to the `root` module: "scalac-options-root".
This is just for the sake of convenience when the project is opened in IDEs (like IntelliJ).
Without such a name it is shown as just "root" which is not very helpful.

I would like it to be just "scalac-options", but this name is already occupied by the `lib` module.