### PR TITLE
Fix version ranges for deprecation options

### DIFF
--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalaVersion.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalaVersion.scala
@@ -29,6 +29,7 @@ object ScalaVersion {
   val V2_12_0  = ScalaVersion(2, 12, 0)
   val V2_12_2  = ScalaVersion(2, 12, 2)
   val V2_12_5  = ScalaVersion(2, 12, 5)
+  val V2_12_13 = ScalaVersion(2, 12, 13)
   val V2_13_0  = ScalaVersion(2, 13, 0)
   val V2_13_2  = ScalaVersion(2, 13, 2)
   val V2_13_3  = ScalaVersion(2, 13, 3)

--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -48,10 +48,7 @@ private[scalacoptions] trait ScalacOptions {
 
   /** Emit warning and location for usages of deprecated APIs.
     */
-  val deprecation = ScalacOption(
-    "-deprecation",
-    version => version < V2_13_0 || version >= V3_0_0
-  )
+  val deprecation = ScalacOption("-deprecation", _ => true)
 
   /** Emit warning and location for usages of features that should be imported explicitly.
     */
@@ -246,7 +243,7 @@ private[scalacoptions] trait ScalacOptions {
   /** Enable linted deprecations.
     */
   val lintDeprecation =
-    lintOption("deprecation", version => version.isBetween(V2_13_0, V3_0_0))
+    lintOption("deprecation", version => version.isBetween(V2_12_13, V3_0_0))
 
   /** Warn when a Scaladoc comment appears to be detached from its element.
     */


### PR DESCRIPTION
Addresses #5:
- `-deprecation` is supported across all the supported Scalac versions
- `-Xlint:deprecation` introduced since v2.12.13, supported across v2.13.x and still not supported in v3.x.y.