### PR TITLE
Add warnNonUnitStatement to Scala 3 (3.3.1)

### DIFF
--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalaVersion.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalaVersion.scala
@@ -42,6 +42,7 @@ object ScalaVersion {
   val V3_0_0   = ScalaVersion(3, 0, 0)
   val V3_1_0   = ScalaVersion(3, 1, 0)
   val V3_3_0   = ScalaVersion(3, 3, 0)
+  val V3_3_1   = ScalaVersion(3, 3, 1)
 
   implicit val scalaVersionOrdering: Ordering[ScalaVersion] =
     Ordering.by(version => (version.major, version.minor, version.patch))

--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -688,7 +688,7 @@ private[scalacoptions] trait ScalacOptions {
   val warnNonUnitStatement =
     warnOption(
       "nonunit-statement",
-      version => version.isBetween(V2_13_9, V3_0_0)
+      version => version.isBetween(V2_13_9, V3_0_0) || version.isAtLeast(V3_3_1)
     )
 
   /** Fail the compilation if there are any warnings.


### PR DESCRIPTION
Ideally, this could be released ASAP and then used in **sbt-tpolecat**.
This is probably the number one linter for **cats-effect** code.