### PR TITLE
Ability to lift a ScalaVersion from a String

### DIFF
--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalaVersion.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalaVersion.scala
@@ -44,6 +44,17 @@ object ScalaVersion {
   val V3_3_0   = ScalaVersion(3, 3, 0)
   val V3_3_1   = ScalaVersion(3, 3, 1)
 
+  private val versionRegex = raw"""(\d+)\.(\d+)\.(\d+)(?:-.*)?""".r
+  def fromString(version: String): Either[IllegalArgumentException, ScalaVersion] =
+    version match {
+      case versionRegex(major, minor, patch) =>
+        Right(ScalaVersion(major.toLong, minor.toLong, patch.toLong))
+      case _ => Left(new IllegalArgumentException(s"Scala version $version not recognized"))
+    }
+
+  def unsafeFromString(version: String): ScalaVersion =
+    fromString(version).fold(throw _, identity)
+
   implicit val scalaVersionOrdering: Ordering[ScalaVersion] =
     Ordering.by(version => (version.major, version.minor, version.patch))
 }

--- a/lib/src/test/scala/org/typelevel/scalacoptions/ScalaVersionSuite.scala
+++ b/lib/src/test/scala/org/typelevel/scalacoptions/ScalaVersionSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalacoptions
+
+import org.scalacheck.Gen
+import org.scalacheck.Prop.forAll
+
+class ScalaVersionSuite extends munit.ScalaCheckSuite {
+  val versionGen = Gen.chooseNum(0L, 20L)
+
+  property("fromString parse a version") {
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val version = ScalaVersion.fromString(s"$currentMaj.$currentMin.$currentPatch")
+        assertEquals(version, Right(ScalaVersion(currentMaj, currentMin, currentPatch)))
+    }
+  }
+
+  property("fromString parse an RC version") {
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val version = ScalaVersion.fromString(s"$currentMaj.$currentMin.$currentPatch-RC3")
+        assertEquals(version, Right(ScalaVersion(currentMaj, currentMin, currentPatch)))
+    }
+  }
+
+  property("fromString parse a NIGHTLY version") {
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val version = ScalaVersion.fromString(
+          s"$currentMaj.$currentMin.$currentPatch-RC1-bin-20231106-f61026d-NIGHTLY"
+        )
+        assertEquals(version, Right(ScalaVersion(currentMaj, currentMin, currentPatch)))
+    }
+  }
+
+  property("fromString parse a commit version") {
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val version = ScalaVersion.fromString(s"$currentMaj.$currentMin.$currentPatch-bin-80514f7")
+        assertEquals(version, Right(ScalaVersion(currentMaj, currentMin, currentPatch)))
+    }
+  }
+}


### PR DESCRIPTION
Hi,

I'm helping @DavidGregory084 to maintain the [mill-tpolecat](https://github.com/DavidGregory084/mill-tpolecat) and I just found out about this project and the split with [sbt-tpolecat](https://github.com/typelevel/sbt-tpolecat). Great idea! and thank you for doing this!

Now I feel like we could deprecate mill-tpolecat and only use this dependency in mill. Here is an example:
```
import $ivy.`org.typelevel::scalac-options:0.1.4`

object `my-project` extends ScalaModule {
  override def scalaVersion = "3.3.1"
  override def scalacOptions = ScalacOptions.defaultTokensForVersion(ScalaVersion.V3_3_0)
}
```
You can see this is very compact already and mill-tpolecat would not really add much value.

However the thing that bothers me is that now we have to edit the Scala version at multiple places.
With this PR it would look like this:
```
import $ivy.`org.typelevel::scalac-options:0.1.4`

object `my-project` extends ScalaModule {
  override def scalaVersion = "3.3.1"
  override def scalacOptions = ScalacOptions.defaultTokensForVersion(ScalaVersion.unsafeFromString(scalaVersion()))
}
```

Thanks