### PR TITLE
Add javaOutputVersion to ScalacOptions for scala >= 3.1.2

### DIFF
--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalaVersion.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalaVersion.scala
@@ -41,6 +41,7 @@ object ScalaVersion {
   val V2_13_9  = ScalaVersion(2, 13, 9)
   val V3_0_0   = ScalaVersion(3, 0, 0)
   val V3_1_0   = ScalaVersion(3, 1, 0)
+  val V3_1_2   = ScalaVersion(3, 1, 2)
   val V3_3_0   = ScalaVersion(3, 3, 0)
   val V3_3_1   = ScalaVersion(3, 3, 1)
   val V3_3_3   = ScalaVersion(3, 3, 3)

--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -82,7 +82,7 @@ private[scalacoptions] trait ScalacOptions {
     ScalacOption(
       "-release",
       List(version),
-      version => JavaMajorVersion.javaMajorVersion >= 9 && version.isBetween(V2_12_5, V3_1_2)
+      version => JavaMajorVersion.javaMajorVersion >= 9 && version >= V2_12_5
     )
 
   /** Enable features that will be available in a future version of Scala, for purposes of early

--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -78,12 +78,11 @@ private[scalacoptions] trait ScalacOptions {
     * The release flag is supported only on JDK 9 and above, since it relies on the functionality
     * provided in [[http://openjdk.java.net/jeps/247 JEP-247: Compile for Older Platform Versions]].
     */
-  @deprecated("Use javaOutputVersion instead", "3.1.2")
   def release(version: String) =
     ScalacOption(
       "-release",
       List(version),
-      version => JavaMajorVersion.javaMajorVersion >= 9 && version >= V2_12_5
+      version => JavaMajorVersion.javaMajorVersion >= 9 && version >= V2_12_5 && version < V3_1_2
     )
 
   /** Enable features that will be available in a future version of Scala, for purposes of early

--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -82,7 +82,7 @@ private[scalacoptions] trait ScalacOptions {
     ScalacOption(
       "-release",
       List(version),
-      version => JavaMajorVersion.javaMajorVersion >= 9 && version >= V2_12_5 && version < V3_1_2
+      version => JavaMajorVersion.javaMajorVersion >= 9 && version.isBetween(V2_12_5, V3_1_2)
     )
 
   /** Enable features that will be available in a future version of Scala, for purposes of early

--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -62,9 +62,23 @@ private[scalacoptions] trait ScalacOptions {
 
   /** Compile for a specific version of the Java platform. Supported targets: 8, 9, ..., 17, 18.
     *
+    * The java-output-version flag is supported only on JDK 9 and above, since it relies on the
+    * functionality provided in
+    * [[http://openjdk.java.net/jeps/247 JEP-247: Compile for Older Platform Versions]].
+    */
+  def javaOutputVersion(version: String) =
+    ScalacOption(
+      "-java-output-version",
+      List(version),
+      version => JavaMajorVersion.javaMajorVersion >= 9 && version >= V3_1_2
+    )
+
+  /** Compile for a specific version of the Java platform. Supported targets: 8, 9, ..., 17, 18.
+    *
     * The release flag is supported only on JDK 9 and above, since it relies on the functionality
     * provided in [[http://openjdk.java.net/jeps/247 JEP-247: Compile for Older Platform Versions]].
     */
+  @deprecated("Use javaOutputVersion instead", "3.1.2")
   def release(version: String) =
     ScalacOption(
       "-release",


### PR DESCRIPTION
Scala 3.1.2 renamed `-release` to `-java-output-version`. [See blog](https://www.scala-lang.org/blog/2022/04/12/scala-3.1.2-released.html).

I'm not very confident that this PR is right but, WDYT?