### PR TITLE
Fix deprecated ykind projector in scala 3.5

### DIFF
--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalaVersion.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalaVersion.scala
@@ -45,6 +45,7 @@ object ScalaVersion {
   val V3_3_1   = ScalaVersion(3, 3, 1)
   val V3_3_3   = ScalaVersion(3, 3, 3)
   val V3_4_0   = ScalaVersion(3, 4, 0)
+  val V3_5_0   = ScalaVersion(3, 5, 0)
 
   private val versionRegex = raw"""(\d+)\.(\d+)\.(\d+)(?:-.*)?""".r
   def fromString(version: String): Either[IllegalArgumentException, ScalaVersion] =

--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -440,7 +440,8 @@ private[scalacoptions] trait ScalacOptions {
   /** Advanced options (-X)
     */
   val advancedOptions: Set[ScalacOption] = ListSet(
-    lint
+    lint,
+    advancedKindProjector
   ) ++ lintOptions
 
   /** Private options (-Y)
@@ -468,7 +469,10 @@ private[scalacoptions] trait ScalacOptions {
     * syntax.
     */
   val privateKindProjector =
-    privateOption("kind-projector", version => version >= V3_0_0)
+    privateOption("kind-projector", version => version.isBetween(V3_0_0, V3_5_0))
+
+  val advancedKindProjector =
+    advancedOption("kind-projector", version => version >= V3_5_0)
 
   /** Enables safe initialization check. More info:
     * [[https://docs.scala-lang.org/scala3/reference/other-new-features/safe-initialization.html]]


### PR DESCRIPTION
kind-project and other has lifted from experiment to stabilized in:
https://github.com/scala/scala3/pull/20199

We need this for scala 3.5.0: https://github.com/typelevel/sbt-tpolecat/issues/223