### PR TITLE
Fix order of initialization regression from #131

### DIFF
--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -212,6 +212,12 @@ private[scalacoptions] trait ScalacOptions {
   def maxInlines(limit: Int) =
     advancedOption("max-inlines", List(limit.toString), version => version >= V3_0_0)
 
+  /** Enables support for a subset of [[https://github.com/typelevel/kind-projector kind-projector]]
+    * syntax.
+    */
+  val advancedKindProjector =
+    advancedOption("kind-projector", version => version >= V3_5_0)
+
   /** Enable recommended warnings.
     */
   def lintOption(
@@ -475,9 +481,6 @@ private[scalacoptions] trait ScalacOptions {
     */
   val privateKindProjector =
     privateOption("kind-projector", version => version.isBetween(V3_0_0, V3_5_0))
-
-  val advancedKindProjector =
-    advancedOption("kind-projector", version => version >= V3_5_0)
 
   /** Enables safe initialization check. More info:
     * [[https://docs.scala-lang.org/scala3/reference/other-new-features/safe-initialization.html]]

--- a/lib/src/test/scala/org/typelevel/scalacoptions/ScalacOptionSuite.scala
+++ b/lib/src/test/scala/org/typelevel/scalacoptions/ScalacOptionSuite.scala
@@ -215,4 +215,15 @@ class ScalacOptionSuite extends munit.ScalaCheckSuite {
         )
     }
   }
+
+  property("ScalacOptions.default should not contain null") {
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val version = ScalaVersion(currentMaj, currentMin, currentPatch)
+        ScalacOptions.default.foreach { option =>
+          assert(option.isSupported(version) || true)
+        }
+    }
+  }
+
 }


### PR DESCRIPTION
When initialize `advancedOptions`, the value of `advancedKindProjector`
is still `null`. That is caused because `advancedOptions` is placed
before `advancedOptions`. This is to fix that issue.

Also add a test to prevent this happen.