### PR TITLE
Add -Wsafe-init for scala 3.5.0

### DIFF
--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -813,6 +813,12 @@ private[scalacoptions] trait ScalacOptions {
       version => version.isBetween(V2_13_0, V3_0_0) || version.isAtLeast(V3_3_0)
     )
 
+  /** Enables safe initialization check. More info:
+    * [[https://docs.scala-lang.org/scala3/reference/other-new-features/safe-initialization.html]]
+    */
+  val warnSafeInit =
+    warnOption("safe-init", version => version >= V3_5_0)
+
   /** Unused warning options (-Wunused:)
     */
   val warnUnusedOptions: Set[ScalacOption] = ListSet(


### PR DESCRIPTION
This is similar to `ykind-projector` in #131, `-Ysafe-init` has been promoted to `-Wsafe-init` in https://github.com/scala/scala3/pull/20199.

Note event thought it's lifted from `-Y` category, but the documentation is still saying that it's an experiment: https://dotty.epfl.ch/docs/reference/other-new-features/safe-initialization.html.