### PR TITLE
Add ScalaVersion toString

### DIFF
--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalaVersion.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalaVersion.scala
@@ -19,10 +19,14 @@ package org.typelevel.scalacoptions
 import scala.Ordering.Implicits._
 
 case class ScalaVersion(major: Long, minor: Long, patch: Long) {
-  def isBetween(addedVersion: ScalaVersion, removedVersion: ScalaVersion) =
+  def isBetween(addedVersion: ScalaVersion, removedVersion: ScalaVersion): Boolean =
     this >= addedVersion && this < removedVersion
 
-  def isAtLeast(addedVersion: ScalaVersion) = this >= addedVersion
+  def isAtLeast(addedVersion: ScalaVersion): Boolean =
+    this >= addedVersion
+
+  override def toString: String =
+    s"$major.$minor.$patch"
 }
 
 object ScalaVersion {

--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOption.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOption.scala
@@ -40,7 +40,7 @@ class ScalacOption(
       case _                  => false
     }
 
-  override def toString =
+  override def toString: String =
     (option :: args).mkString("ScalacOption(", " ", ")")
 }
 


### PR DESCRIPTION
This PR adds the `toString` implementation to the `ScalaVersion` class