### PR TITLE
Add -Wimplausible-patterns option

### DIFF
--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -825,6 +825,15 @@ private[scalacoptions] trait ScalacOptions {
   val warnSafeInit =
     warnOption("safe-init", version => version >= V3_5_0)
 
+  /** Warn if comparison with a pattern value looks like it might always fail.
+    *
+    * [[https://github.com/scala/scala3/pull/18093]]
+    *
+    * Added in 3.4.0.
+    */
+  val warnImplausiblePatterns =
+    warnOption("implausible-patterns", version => version >= V3_4_0)
+
   /** Unused warning options (-Wunused:)
     */
   val warnUnusedOptions: Set[ScalacOption] = ListSet(

--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -856,7 +856,6 @@ private[scalacoptions] trait ScalacOptions {
   val warnAll =
     warnOption("all", version => version.isAtLeast(V3_5_2) || version.isBetween(V3_3_5, V3_4_0))
 
-
   /** Unused warning options (-Wunused:)
     */
   val warnUnusedOptions: Set[ScalacOption] = ListSet(


### PR DESCRIPTION
I wonder should we include this to default options. It seems very useful but not sure how stable it is.

reference:
- https://github.com/scala/scala3/pull/18093
- https://github.com/scala/scala3/issues/21618