### PR TITLE
Remove unnecessary higherKinds option if latest Scala 2.13.x and 3.x

### DIFF
--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -164,7 +164,7 @@ private[scalacoptions] trait ScalacOptions {
   /** Allow higher-kinded types.
     */
   val languageHigherKinds =
-    languageFeatureOption("higherKinds")
+    languageFeatureOption("higherKinds", _ <= V2_13_0)
 
   /** Allow definition of implicit functions called views.
     */


### PR DESCRIPTION
https://github.com/scala/scala/commit/f48672c566fda7c81ca995c983a3dad39c86d15c