### PR TITLE
Support -Wunused:patvars on Scala 3

### DIFF
--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalaVersion.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalaVersion.scala
@@ -51,9 +51,11 @@ object ScalaVersion {
   val V3_3_1   = ScalaVersion(3, 3, 1)
   val V3_3_3   = ScalaVersion(3, 3, 3)
   val V3_3_5   = ScalaVersion(3, 3, 5)
+  val V3_3_7   = ScalaVersion(3, 3, 7)
   val V3_4_0   = ScalaVersion(3, 4, 0)
   val V3_5_0   = ScalaVersion(3, 5, 0)
   val V3_5_2   = ScalaVersion(3, 5, 2)
+  val V3_7_0   = ScalaVersion(3, 7, 0)
   val V3_8_3   = ScalaVersion(3, 8, 3)
 
   private val versionRegex = raw"""(\d+)\.(\d+)\.(\d+)(?:-.*)?""".r

--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -836,9 +836,20 @@ private[scalacoptions] trait ScalacOptions {
     )
 
   /** Warn if a variable bound in a pattern is unused.
+    *
+    * Added in 2.13.0. In Scala 3, only available as the unsafe variant
+    * `-Wunused:unsafe-warn-patvars` until 3.7.0, when it was forward-ported from
+    * Scala 2 as a safe `-Wunused:patvars` ([[https://github.com/scala/scala3/pull/20894]]).
+    * Backported to the 3.3 LTS in 3.3.7 ([[https://github.com/scala/scala3-lts/pull/223]]).
     */
   val warnUnusedPatVars =
-    warnUnusedOption("patvars", version => version.isBetween(V2_13_0, V3_0_0))
+    warnUnusedOption(
+      "patvars",
+      version =>
+        version.isBetween(V2_13_0, V3_0_0) ||
+          version.isBetween(V3_3_7, V3_4_0) ||
+          version.isAtLeast(V3_7_0)
+    )
 
   /** Warn if a private member is unused.
     *

--- a/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
+++ b/lib/src/main/scala/org/typelevel/scalacoptions/ScalacOptions.scala
@@ -838,9 +838,9 @@ private[scalacoptions] trait ScalacOptions {
   /** Warn if a variable bound in a pattern is unused.
     *
     * Added in 2.13.0. In Scala 3, only available as the unsafe variant
-    * `-Wunused:unsafe-warn-patvars` until 3.7.0, when it was forward-ported from
-    * Scala 2 as a safe `-Wunused:patvars` ([[https://github.com/scala/scala3/pull/20894]]).
-    * Backported to the 3.3 LTS in 3.3.7 ([[https://github.com/scala/scala3-lts/pull/223]]).
+    * `-Wunused:unsafe-warn-patvars` until 3.7.0, when it was forward-ported from Scala 2 as a safe
+    * `-Wunused:patvars` ([[https://github.com/scala/scala3/pull/20894]]). Backported to the 3.3 LTS
+    * in 3.3.7 ([[https://github.com/scala/scala3-lts/pull/223]]).
     */
   val warnUnusedPatVars =
     warnUnusedOption(

--- a/lib/src/test/scala/org/typelevel/scalacoptions/ScalacOptionSuite.scala
+++ b/lib/src/test/scala/org/typelevel/scalacoptions/ScalacOptionSuite.scala
@@ -228,6 +228,29 @@ class ScalacOptionSuite extends munit.ScalaCheckSuite {
     assert(ScalacOptions.privateCheckAllPatmat.isSupported(ScalaVersion(3, 3, 0)))
   }
 
+  test("warnUnusedPatVars is supported on Scala 2.13") {
+    assert(ScalacOptions.warnUnusedPatVars.isSupported(ScalaVersion(2, 13, 0)))
+    assert(ScalacOptions.warnUnusedPatVars.isSupported(ScalaVersion(2, 13, 14)))
+  }
+
+  test("warnUnusedPatVars is not supported on Scala 3 versions where only the unsafe variant exists") {
+    assert(!ScalacOptions.warnUnusedPatVars.isSupported(ScalaVersion(3, 0, 0)))
+    assert(!ScalacOptions.warnUnusedPatVars.isSupported(ScalaVersion(3, 3, 0)))
+    assert(!ScalacOptions.warnUnusedPatVars.isSupported(ScalaVersion(3, 3, 6)))
+    assert(!ScalacOptions.warnUnusedPatVars.isSupported(ScalaVersion(3, 4, 0)))
+    assert(!ScalacOptions.warnUnusedPatVars.isSupported(ScalaVersion(3, 6, 4)))
+  }
+
+  test("warnUnusedPatVars is supported on the 3.3 LTS from 3.3.7") {
+    assert(ScalacOptions.warnUnusedPatVars.isSupported(ScalaVersion(3, 3, 7)))
+    assert(ScalacOptions.warnUnusedPatVars.isSupported(ScalaVersion(3, 3, 99)))
+  }
+
+  test("warnUnusedPatVars is supported on Scala 3 from 3.7.0") {
+    assert(ScalacOptions.warnUnusedPatVars.isSupported(ScalaVersion(3, 7, 0)))
+    assert(ScalacOptions.warnUnusedPatVars.isSupported(ScalaVersion(3, 8, 3)))
+  }
+
   property("ScalacOptions.default should not contain null") {
     forAll(versionGen, versionGen, versionGen) {
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>

--- a/lib/src/test/scala/org/typelevel/scalacoptions/ScalacOptionSuite.scala
+++ b/lib/src/test/scala/org/typelevel/scalacoptions/ScalacOptionSuite.scala
@@ -233,7 +233,9 @@ class ScalacOptionSuite extends munit.ScalaCheckSuite {
     assert(ScalacOptions.warnUnusedPatVars.isSupported(ScalaVersion(2, 13, 14)))
   }
 
-  test("warnUnusedPatVars is not supported on Scala 3 versions where only the unsafe variant exists") {
+  test(
+    "warnUnusedPatVars is not supported on Scala 3 versions where only the unsafe variant exists"
+  ) {
     assert(!ScalacOptions.warnUnusedPatVars.isSupported(ScalaVersion(3, 0, 0)))
     assert(!ScalacOptions.warnUnusedPatVars.isSupported(ScalaVersion(3, 3, 0)))
     assert(!ScalacOptions.warnUnusedPatVars.isSupported(ScalaVersion(3, 3, 6)))


### PR DESCRIPTION
## Summary

- Enable `-Wunused:patvars` on Scala 3 versions where the safe variant is available
- Earlier Scala 3 versions only offered `-Wunused:unsafe-warn-patvars`, which this library does not expose
- The safe `-Wunused:patvars` was forward-ported from Scala 2 in 3.7.0 ([scala/scala3#20894](https://github.com/scala/scala3/pull/20894)) and backported to the 3.3 LTS in 3.3.7 ([scala/scala3-lts#223](https://github.com/scala/scala3-lts/pull/223))

The resulting gating is `[2.13.0, 3.0.0) ∪ [3.3.7, 3.4.0) ∪ [3.7.0, ∞)`.

Note: the LTS PR description claims it was backported "to the 3.3.6", but that PR did not actually ship in 3.3.6 — it landed in 3.3.7 (confirmed in the [3.3.7 release notes](https://github.com/scala/scala3/releases/tag/3.3.7) which list #20894 under "Highlights").

## Test plan

- [x] Added unit tests covering each boundary (2.13, 3.0.0, 3.3.0, 3.3.6, 3.3.7, 3.4.0, 3.6.x, 3.7.0, 3.8.x)
- [x] Verified empirically with `scala-cli`: `-Wunused:patvars` is rejected on 3.3.6 and 3.6.4, accepted on 3.3.7 and 3.7.0
- [x] `sbt libJVM/test` passes (26/26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)